### PR TITLE
refactored the http clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Ignore the bin directory
 **/bin/
+
+# Ignore the secrets file
+**/secrets.json

--- a/api/Data/ShippingDb.cs
+++ b/api/Data/ShippingDb.cs
@@ -15,8 +15,8 @@ class ShippingDb : DbContext
         base.OnModelCreating(modelBuilder);
         modelBuilder.Entity<ShippingCompany>()
             .HasData(
-                new ShippingCompany { Id = 1, Name = "UPS", AccountNumber="12345", AccountKey="fda5432fda", ApiUrl="https://wwwcie.ups.com/api"},
-                new ShippingCompany { Id = 2, Name = "Fed Ex", AccountNumber="67890", AccountKey="req987reqw", ApiUrl="https://apis-sandbox.fedex.com"}
+                new ShippingCompany { Id = 1, Name = "UPS", AccountNumber="12345"},
+                new ShippingCompany { Id = 2, Name = "Fed Ex", AccountNumber="67890"}
             );
         modelBuilder.Entity<Address>()
             .HasData(

--- a/api/Extensions/ApplicationServiceExtensions.cs
+++ b/api/Extensions/ApplicationServiceExtensions.cs
@@ -1,10 +1,35 @@
 
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+
 static class ApplicationServiceExtensions
 {
-    public static void AddHttpClients(this IServiceCollection services)
+    public static void AddUpsHttpClient(this IServiceCollection services, IConfiguration config)
     {
-        services.AddHttpClient<UpsHttpClient>();
-        services.AddHttpClient<FedExHttpClient>();
+        services.Configure<UpsHttpClientSettings>(config.GetSection("UpsHttpClient"));
+        var clientSettings = config.GetSection("UpsHttpClient").Get<UpsHttpClientSettings>();
+
+        services.AddHttpClient<UpsHttpClient>(client =>
+        {
+            client.BaseAddress = new Uri($"{clientSettings!.Url}/addressvalidation/v1/1?regionalrequestindicator=string&maximumcandidatelistsize=1");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", clientSettings.ApiKey);
+            client.DefaultRequestHeaders.Add("X-Locale", "en_US");
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
+        });        
+    }
+
+    public static void AddFedExHttpClient(this IServiceCollection services, IConfiguration config)
+    {
+        services.Configure<FedExHttpClientSettings>(config.GetSection("FedExHttpClient"));
+
+        services.AddHttpClient<FedExHttpClient>(client =>
+        {
+            var clientSettings = config.GetSection("FedExHttpClient").Get<FedExHttpClientSettings>();
+            client.BaseAddress = new Uri($"{clientSettings!.Url}/address/v1/addresses/resolve");
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", clientSettings.ApiKey);
+            client.DefaultRequestHeaders.Add("X-Locale", "en_US");
+            client.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
+        });
     }
 
     public static void AddFactories(this IServiceCollection services)

--- a/api/Factories/ShippingHttpClientFactory.cs
+++ b/api/Factories/ShippingHttpClientFactory.cs
@@ -10,6 +10,6 @@ class ShippingHttpClientFactory(Func<ShippingCompanyType, IShippingHttpClientFac
         var shippingCompanyType = (ShippingCompanyType)shippingCompany.Id;
         var factory = factoryResolver(shippingCompanyType);
 
-        return factory.CreateHttpClient(shippingCompany);
+        return factory.CreateHttpClient();
     }
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -1,15 +1,16 @@
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
+var configuration = builder.Configuration;
 
 builder.Services.AddDbContext<ShippingDb>(options =>
     options.UseInMemoryDatabase("Addresses"));
 
 builder.Services.AddServices();
 builder.Services.AddFactories();
-builder.Services.AddHttpClients();
+builder.Services.AddUpsHttpClient(configuration);
+builder.Services.AddFedExHttpClient(configuration);
 builder.Services.AddEndpointsApiExplorer();
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -34,6 +35,7 @@ using (var scope = app.Services.CreateScope())
 
 app.MapPost("/validate-address", async (AddressValidationRequest addressValidationRequest, ShippingHttpClientFactory factory, ShippingCompanyService shippingCompanyService, AddressService addressService) =>
 {
+    //HttpResponseMessage response;
     string response;
     using (var scope = app.Services.CreateScope())
     {

--- a/api/Settings/FedExHttpClientSettings.cs
+++ b/api/Settings/FedExHttpClientSettings.cs
@@ -1,0 +1,6 @@
+
+public class FedExHttpClientSettings
+{
+    public required string Url { get; set; }
+    public required string ApiKey { get; set; }
+}

--- a/api/Settings/UpsHttpClientSettings.cs
+++ b/api/Settings/UpsHttpClientSettings.cs
@@ -1,0 +1,6 @@
+
+public class UpsHttpClientSettings
+{
+    public required string Url { get; set; }
+    public required string ApiKey { get; set; }
+}

--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -4,5 +4,13 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "UpsHttpClient" : {
+    "Url": "https://wwwcie.ups.com/api",
+    "ApiKey": "ups.test.api.key"
+  },
+  "FedExHttpClient" : {
+    "Url": "https://apis-sandbox.fedex.com",
+    "ApiKey": "fed.ex.test.api.key"
   }
 }

--- a/common/Factories/IShippingHttpClientFactory.cs
+++ b/common/Factories/IShippingHttpClientFactory.cs
@@ -1,4 +1,4 @@
 public interface IShippingHttpClientFactory
 {
-    IShippingHttpClient CreateHttpClient(ShippingCompany shippingCompany);
+    IShippingHttpClient CreateHttpClient();
 }

--- a/fed-ex/Factories/FedExHttpClientFactory.cs
+++ b/fed-ex/Factories/FedExHttpClientFactory.cs
@@ -1,12 +1,11 @@
-public class FedExHttpClientFactory(IHttpClientFactory httpClientFactory, FedExAddressValidationRequestBuilder fedExAddressValidationRequestBuilder) : IShippingHttpClientFactory
+public class FedExHttpClientFactory(IHttpClientFactory httpClientFactory, IAddressValidationRequestBuilder fedExAddressValidationRequestBuilder) : IShippingHttpClientFactory
 {
-    public IShippingHttpClient CreateHttpClient(ShippingCompany shippingCompany)
+    public IShippingHttpClient CreateHttpClient()
     {
         return new FedExHttpClient
         (
-            httpClientFactory.CreateClient(),
-            fedExAddressValidationRequestBuilder,
-            shippingCompany
+            httpClientFactory.CreateClient("FedExHttpClient"),
+            (FedExAddressValidationRequestBuilder)fedExAddressValidationRequestBuilder
         );
     }
 }

--- a/fed-ex/HttpClients/FedExHttpClient.cs
+++ b/fed-ex/HttpClients/FedExHttpClient.cs
@@ -4,31 +4,31 @@ using System.Text;
 public class FedExHttpClient : IShippingHttpClient
 {
     private readonly HttpClient _httpClient;
-    private FedExAddressValidationRequestBuilder _builder;
+    private IAddressValidationRequestBuilder _builder;
 
     /// <summary>
     /// https://developer.fedex.com/api/en-us/catalog/address-validation/v1/docs.html#operation/Validate%20Address
     /// </summary>
     public FedExHttpClient(
         HttpClient httpClient, 
-        FedExAddressValidationRequestBuilder builder,
-        ShippingCompany shippingCompany)
+        IAddressValidationRequestBuilder builder)
     {
         _httpClient = httpClient;
         _builder = builder;
-
-        _httpClient.BaseAddress = new Uri($"{shippingCompany.ApiUrl}/address/v1/addresses/resolve");
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", shippingCompany.AccountKey);
-        _httpClient.DefaultRequestHeaders.Add("X-Locale", "en_US");
-        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
     }
 
     public async Task<string> ValidateAddress(Address address)
     {
-        _builder.BuildAddressRequest(address);
-        var request = _builder.SerializeRequest();
+        var request = BuildAddressRequest(address);
         var content = new StringContent(request, Encoding.UTF8, "application/json");
-        // since we do not have an actual Fed Ex account, return the request payload
-        return request;        // return await _httpClient.PostAsync(_httpClient.BaseAddress, content);
+        // since we do not have an actual Fed Ex account, return the request payload             
+        //return await _httpClient.PostAsync(_httpClient.BaseAddress, content);
+        return request;   
+    }
+
+    private string BuildAddressRequest(Address address)
+    {
+        _builder.BuildAddressRequest(address);
+        return _builder.SerializeRequest();
     }
 }

--- a/models/ShippingCompany.cs
+++ b/models/ShippingCompany.cs
@@ -3,6 +3,4 @@
     public int Id { get; set; }
     public required string Name { get; set; }
     public required string AccountNumber {get;set;}
-    public required string AccountKey {get;set;}    
-    public required string ApiUrl {get;set;}
 }

--- a/ups/Factories/UpsHttpClientFactory.cs
+++ b/ups/Factories/UpsHttpClientFactory.cs
@@ -1,12 +1,11 @@
-public class UpsHttpClientFactory(IHttpClientFactory httpClientFactory, UpsAddressValidationRequestBuilder upsAddressValidationRequestBuilder) : IShippingHttpClientFactory
+public class UpsHttpClientFactory(IHttpClientFactory httpClientFactory, IAddressValidationRequestBuilder upsAddressValidationRequestBuilder) : IShippingHttpClientFactory
 {
-    public IShippingHttpClient CreateHttpClient(ShippingCompany shippingCompany)
+    public IShippingHttpClient CreateHttpClient()
     {
         return new UpsHttpClient
         (
-            httpClientFactory.CreateClient(),
-            upsAddressValidationRequestBuilder,
-            shippingCompany
+            httpClientFactory.CreateClient("UpsHttpClient"),
+            (UpsAddressValidationRequestBuilder)upsAddressValidationRequestBuilder
         );
     }
 }

--- a/ups/HttpClients/UpsHttpClient.cs
+++ b/ups/HttpClients/UpsHttpClient.cs
@@ -4,30 +4,31 @@ using System.Text;
 public class UpsHttpClient : IShippingHttpClient
 {
     private readonly HttpClient _httpClient;
-    private UpsAddressValidationRequestBuilder _builder;
+    private IAddressValidationRequestBuilder _builder;
 
     /// <summary>
     /// https://developer.ups.com/api/reference?loc=en_US#operation/AddressValidation
     /// </summary>
     public UpsHttpClient(
         HttpClient httpClient, 
-        UpsAddressValidationRequestBuilder builder,
-        ShippingCompany shippingCompany)
+        IAddressValidationRequestBuilder builder)
     {
-        _httpClient = httpClient;
-        _httpClient.BaseAddress = new Uri($"{shippingCompany.ApiUrl}/addressvalidation/v1/1?regionalrequestindicator=string&maximumcandidatelistsize=1");
-        _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", shippingCompany.AccountKey);
-        _httpClient.DefaultRequestHeaders.Add("X-Locale", "en_US");
-        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("Content-Type", "application/json");
+        _httpClient = httpClient;        
         _builder = builder;
     }
 
     public async Task<string> ValidateAddress(Address address)
     {
-        _builder.BuildAddressRequest(address);
-        var request = _builder.SerializeRequest();
+        var request = BuildAddressRequest(address);
         var content = new StringContent(request, Encoding.UTF8, "application/json");
-        // since we do not have an actual UPS account, return the request payload
-        return request;        // return await _httpClient.PostAsync(_httpClient.BaseAddress, content);
+        // since we do not have an actual UPS account, return the request payload        
+        //return await _httpClient.PostAsync(_httpClient.BaseAddress, content);
+        return request;
+    }
+
+    private string BuildAddressRequest(Address address)
+    {
+        _builder.BuildAddressRequest(address);
+        return _builder.SerializeRequest();
     }
 }


### PR DESCRIPTION
In this branch, we moved the http client configuration from the http client constructor to when the dependency is being built. 

We also moved the http client api key from the ShippingCompany object to the appsettings.Development.json file. 