### PR TITLE
Refactor factories to use an abstract base class

### DIFF
--- a/api/Factories/AddressValidationBuilderFactory.cs
+++ b/api/Factories/AddressValidationBuilderFactory.cs
@@ -1,16 +1,9 @@
-
-public class AddressValidationBuilderFactory(Func<ShippingProviderType, IAddressValidationRequestBuilderFactory> factoryResolver)
+public class AddressValidationBuilderFactory(Func<ShippingProviderType, IAddressValidationRequestBuilderFactory> factoryResolver) : 
+    BaseFactory<IAddressValidationRequestBuilderFactory>(factoryResolver)
 {
-    public IAddressValidationRequestBuilder CreateBuilderFactory(int shippingCompanyId)
+    public IAddressValidationRequestBuilder CreateBuilder(int shippingCompanyId)
     {
-        if (!Enum.IsDefined(typeof(ShippingProviderType), shippingCompanyId))
-        {
-            throw new ArgumentException("Invalid shipping company ID");
-        }
-
-        var shippingCompanyType = (ShippingProviderType)shippingCompanyId;
-        var factory = factoryResolver(shippingCompanyType);
-
+        var factory = GetFactory(shippingCompanyId);
         return factory.CreateBuilder();
     }
 }

--- a/api/Factories/BaseFactory.cs
+++ b/api/Factories/BaseFactory.cs
@@ -1,0 +1,13 @@
+public abstract class BaseFactory<TFactory>(Func<ShippingProviderType, TFactory> factoryResolver)
+{
+    protected TFactory GetFactory(int shippingCompanyId)
+    {
+        if (!Enum.IsDefined(typeof(ShippingProviderType), shippingCompanyId))
+        {
+            throw new ArgumentException("Invalid shipping company ID");
+        }
+
+        var shippingCompanyType = (ShippingProviderType)shippingCompanyId;
+        return factoryResolver(shippingCompanyType);
+    }
+}

--- a/api/Factories/ShippingProviderHttpClientFactory.cs
+++ b/api/Factories/ShippingProviderHttpClientFactory.cs
@@ -1,15 +1,9 @@
-class ShippingProviderHttpClientFactory(Func<ShippingProviderType, IShippingProviderHttpClientFactory> factoryResolver)
-{   
-    public IShippingProviderHttpClient CreateHttpClientFactory(int shippingCompanyId)
+public class ShippingProviderHttpClientFactory(Func<ShippingProviderType, IShippingProviderHttpClientFactory> factoryResolver) : 
+    BaseFactory<IShippingProviderHttpClientFactory>(factoryResolver)
+{
+    public IShippingProviderHttpClient CreateHttpClient(int shippingCompanyId)
     {
-        if (!Enum.IsDefined(typeof(ShippingProviderType), shippingCompanyId))
-        {
-            throw new ArgumentException("Invalid shipping company ID");
-        }
-
-        var shippingCompanyType = (ShippingProviderType)shippingCompanyId;
-        var factory = factoryResolver(shippingCompanyType);
-
+        var factory = GetFactory(shippingCompanyId);
         return factory.CreateHttpClient();
     }
 }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -48,7 +48,7 @@ app.MapPost("/validate-address", async
     string response;
     using (var scope = app.Services.CreateScope())
     {
-        var addressValidationRequestBuilder = addressValidationBuilderFactory.CreateBuilderFactory(addressValidationRequest.ShippingCompanyId);
+        var addressValidationRequestBuilder = addressValidationBuilderFactory.CreateBuilder(addressValidationRequest.ShippingCompanyId);
         var address = await addressService.GetAddressAsync(addressValidationRequest.AddressId);
 
         var requestPayload = addressValidationRequestBuilder
@@ -56,7 +56,7 @@ app.MapPost("/validate-address", async
                                 .SerializeRequest();
 
         var addressValidationEndpoint = uriEndpointProvider.GetAddressValidationEndpoint(addressValidationRequest.ShippingCompanyId);
-        var httpClient = httpClientFactory.CreateHttpClientFactory(addressValidationRequest.ShippingCompanyId);
+        var httpClient = httpClientFactory.CreateHttpClient(addressValidationRequest.ShippingCompanyId);
         response = httpClient.SendRequest(addressValidationEndpoint, requestPayload);
     }
     return Results.Ok(response);


### PR DESCRIPTION
Created a base abstract class for the factory resolvers to reduce duplicated code in the ShippingProviderHttpClientFactory and the AddressValidationBuilderFactory objects