### PR TITLE
fix the Auth0 setup

### DIFF
--- a/api/Program.cs
+++ b/api/Program.cs
@@ -39,8 +39,7 @@ builder.Services.AddAuthentication(options =>
         new Microsoft.IdentityModel.Tokens.TokenValidationParameters
         {
             ValidAudience = configuration["Auth0:Audience"],
-            ValidIssuer = $"{configuration["Auth0:Domain"]}",
-            ValidateLifetime = true,
+            ValidIssuer = $"{builder.Configuration["Auth0:Domain"]}"
         };
 });
 builder.Services.AddAuthorization();

--- a/api/appsettings.Development.json
+++ b/api/appsettings.Development.json
@@ -14,5 +14,9 @@
     "BaseAddress": "https://apis-sandbox.fedex.com/",
     "AddressValidationEndpoint": "address/v1/addresses/resolve",
     "ApiKey": "fed.ex.test.api.key"
-  }
+  },
+  "Auth0" : {
+    "Domain": "dev-4jhqtnyilxvcs8mo.us.auth0.com",
+    "Audience": "http://localhost:5242"
+  }  
 }


### PR DESCRIPTION
There were a couple of issues

- The Auth0:Audience parameter had a trailing '/' when the identifier configured in Auth0 did not have the trailing '/'
- The Auth0:Domain parameter was prefixed with an 'https://'. This was not necessary as the Program.cs file was prefixing this to the URL
- Also had to update the Auth0:domain key/value pair in the Azure App Configuration Store
- I had to to go Auth0 > APIs > Machine to Machine Applications and make sure 'Authorized' was checked for the APIs in question 